### PR TITLE
Add stub [IsolatedContext] definition

### DIFF
--- a/isolated-contexts.bs
+++ b/isolated-contexts.bs
@@ -26,7 +26,7 @@ spec:webidl; type:dfn; text:namespace
 This specification is currently being drafted. In the meantime, please see the
 [Isolated Web Apps Explainer](https://github.com/WICG/isolated-web-apps).
 
-<h1 id="isolated context">Isolated Contexts</h1>
+<h1 id="isolated-contexts">Isolated Contexts</h1>
 
 <dfn export>Isolated context</dfn> will be defined here.
 

--- a/isolated-contexts.bs
+++ b/isolated-contexts.bs
@@ -17,8 +17,33 @@ Abstract:
 Markup Shorthands: markdown yes
 </pre>
 
-Introduction {#intro}
-=====================
+<pre class="link-defaults">
+spec:webidl; type:dfn; text:namespace
+</pre>
+
+<h1 id="introduction">Introduction</h1>
 
 This specification is currently being drafted. In the meantime, please see the
 [Isolated Web Apps Explainer](https://github.com/WICG/isolated-web-apps).
+
+<h1 id="isolated context">Isolated Contexts</h1>
+
+<dfn export>Isolated context</dfn> will be defined here.
+
+<h2 id="IsolatedContext" extended-attribute lt="IsolatedContext">[IsolatedContext]</h2>
+
+If the [{{IsolatedContext}}] [=extended attribute=] appears on an
+[=interface=],
+[=partial interface=],
+[=interface mixin=],
+[=partial interface mixin=],
+[=callback interface=],
+[=namespace=],
+[=partial namespace=],
+[=interface member=],
+[=interface mixin member=], or
+[=namespace member=],
+it indicates that the construct is [=exposed=]
+only within a [=isolated context=].
+The [{{IsolatedContext}}] extended attribute must not be used
+on any other construct.


### PR DESCRIPTION
This adds empty definitions for both "isolated contexts" and the [IsolatedContext] IDL attribute. A more complete spec is in progress, but this will allow other specs to reference the IDL attribute.