### PR TITLE
Avoid re-dfn-ing terms in monkey patches

### DIFF
--- a/isolated-contexts.bs
+++ b/isolated-contexts.bs
@@ -576,8 +576,8 @@ and a [=response=] |response|, run these steps. Possible return values are
 ### Patches to the "Main Fetch" algorithm ### {#fetch-main-fetch}
 The [=main fetch=] algorithm is extended as follows:
 
-<div algorithm>
-To <dfn id="monkey-main-fetch">main fetch</dfn>, given a
+<div>
+To <strong id="monkey-main-fetch">main fetch</strong>, given a
 [=fetch params=] |fetchParams| and an optional boolean
 <var ignore>recursive</var> (default false), run these steps:
 
@@ -660,9 +660,9 @@ that does specify [{{IsolatedContext}}].
 WebIDL's [=exposed=] algorithm is adjusted as follows, adding a single step
 after similarly handling [{{CrossOriginIsolated}}] (step 4 below).
 
-<div algorithm>
+<div>
   An [=interface=], [=callback interface=], [=namespace=], or [=member=]
-  |construct| is <dfn id="dfn-exposed" export>exposed</dfn> in a given
+  |construct| is <strong id="dfn-exposed" export>exposed</strong> in a given
   [=realm=] |realm| if the following steps return true:
 
   <ol>


### PR DESCRIPTION
This helps avoid creating duplicate `dfn` when extracted for re-use by Bikeshed


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/isolated-web-apps/pull/49.html" title="Last updated on Aug 23, 2024, 10:50 AM UTC (52618ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/isolated-web-apps/49/a6ecf5d...dontcallmedom:52618ba.html" title="Last updated on Aug 23, 2024, 10:50 AM UTC (52618ba)">Diff</a>