### PR TITLE
Add .html suffix to spec URL in isolated-contexts.bs

### DIFF
--- a/isolated-contexts.bs
+++ b/isolated-contexts.bs
@@ -4,7 +4,7 @@ Shortname: isolated-contexts
 Level: 1
 Group: wicg
 Status: w3c/CG-DRAFT
-ED: https://wicg.github.io/isolated-web-apps/isolated-contexts
+ED: https://wicg.github.io/isolated-web-apps/isolated-contexts.html
 Repository: https://github.com/WICG/isolated-web-apps
 
 Editor: Robbie McElrath 139758, Google LLC https://google.com, rmcelrath@google.com


### PR DESCRIPTION
This will help to not confuse specref tooling. See https://github.com/w3c/browser-specs/pull/1467#issuecomment-2308246059


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/robbiemc/isolated-web-apps/pull/50.html" title="Last updated on Aug 26, 2024, 8:40 PM UTC (0156e9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/isolated-web-apps/50/badfe33...robbiemc:0156e9b.html" title="Last updated on Aug 26, 2024, 8:40 PM UTC (0156e9b)">Diff</a>